### PR TITLE
Seat group overwrite

### DIFF
--- a/js/views/modules/seat.js
+++ b/js/views/modules/seat.js
@@ -14,6 +14,7 @@ function WarpSeat(sid,seatData,zonesNames,usersNames,factory) {
     this.sid = sid;
     this.zoneName = zonesNames[seatData.zid];
     this.otherZone = !('x' in seatData && 'y' in seatData);
+    this.group = seatData.group;
 
     this._setData(seatData,usersNames);
 
@@ -145,16 +146,19 @@ WarpSeatFactory.prototype.updateLogin = function(login, seatsData) {
 
 /**
  * Returns a list of my bookings which conflicts in the given datetime
+ * @param group group to filter bookings
  * @param raw if true returns an array of bid's
  * @returns array of { sid: 10, bid: 10, fromTS: 1, toTS: 2, zone_name = "Zone 1", seat_name: "Seat 1", datetime1: "yyyy-mm-dd", datetime2: "hh:mm-hh:mm" }
  */
- WarpSeatFactory.prototype.getMyConflictingBookings = function(raw = false) {
+ WarpSeatFactory.prototype.getMyConflictingBookings = function(group, raw = false) {
 
     var res = [];
 
     for (var sid of this.myConflictingBookings) {
 
         var seat = this.instances[sid];
+        if (seat.group != group)
+            continue;
 
         for (let i of seat._bookingsIterator()) {
 
@@ -412,7 +416,8 @@ WarpSeat.prototype._updateView = function() {
             this.seatDiv.style.backgroundPositionX = WarpSeat.Sprites.userConflictOffset;
             break;
         case WarpSeat.SeatStates.CAN_BOOK:
-            if (this.factory.myConflictingBookings.size > 0) {
+            const conflictingBookings = this.factory.getMyConflictingBookings(this.group)
+            if (conflictingBookings.length > 0) {
                 this.state = WarpSeat.SeatStates.CAN_REBOOK;    //this is not very elegant
                 this.seatDiv.style.backgroundPositionX =
                     assignedToMe ? WarpSeat.Sprites.rebookAssignedOffset : WarpSeat.Sprites.rebookOffset;

--- a/js/views/modules/zoneModify_seat.js
+++ b/js/views/modules/zoneModify_seat.js
@@ -178,6 +178,7 @@ Seat._setterFactory = function(propName,mutator = a => a) {
 Object.defineProperty(Seat.prototype, "name", { get: Seat._getterFactory('name'), set: Seat._setterFactory('name') } );
 Object.defineProperty(Seat.prototype, "x", { get: Seat._getterFactory('x'), set: Seat._setterFactory('x',(a) => Math.max(Math.round(a),0)) } );
 Object.defineProperty(Seat.prototype, "y", { get: Seat._getterFactory('y'), set: Seat._setterFactory('y',(a) => Math.max(Math.round(a),0)) } );
+Object.defineProperty(Seat.prototype, "group", { get: Seat._getterFactory('group'), set: Seat._setterFactory('group', (a) => a ? +a : null) } );
 
 function SeatFactory(url,parentDiv,zoneMapImg) {
 

--- a/js/views/zone.js
+++ b/js/views/zone.js
@@ -337,7 +337,7 @@ function initActionMenu(seatFactory) {
         if (removeMsg) {
 
             var myConflictsTable = document.createElement("table");
-            for (let c of seatFactory.getMyConflictingBookings()) {
+            for (let c of seatFactory.getMyConflictingBookings(this.group)) {
                 let tr = myConflictsTable.appendChild(document.createElement("tr"));
                 tr.appendChild( document.createElement("td")).innerText = c.zone_name
                 tr.appendChild( document.createElement("td")).innerText = c.seat_name;
@@ -413,7 +413,7 @@ function initActionMenu(seatFactory) {
         }
 
         if (this.dataset.action == 'delete' || this.dataset.action == 'update') {
-            applyData['remove'] = seatFactory.getMyConflictingBookings(true);
+            applyData['remove'] = seatFactory.getMyConflictingBookings(seat.group, true);
         }
 
         Utils.xhr.post(

--- a/js/views/zoneModify.js
+++ b/js/views/zoneModify.js
@@ -52,6 +52,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
     let seatNameEl = document.getElementById("seat_name");
     let seatXEl = document.getElementById("seat_x");
     let seatYEl = document.getElementById("seat_y");
+    let seatGroupEl = document.getElementById("seat_group");
     let seatDeleteBtn = document.getElementById('seat_delete_btn');
 
     let seatFactory = new SeatFactory(window.warpGlobals.URLs['zonesGetSeats'],zoneMapContainer,zoneMapImg);
@@ -195,6 +196,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
         seatNameEl.value = seat.name;
         seatXEl.value = seat.x;
         seatYEl.value = seat.y;
+        seatGroupEl.value = seat.group;
         M.updateTextFields();
         seatEditPanel.style.visibility = "visible";
     });
@@ -263,6 +265,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
     seatNameEl.addEventListener('input', changeFactory('name'));
     seatXEl.addEventListener('input', changeFactory('x'));
     seatYEl.addEventListener('input', changeFactory('y'));
+    seatGroupEl.addEventListener('input', changeFactory('group'));
 
     var seatXYMax = function() {
         seatXEl.max = zoneMapImg.width - spriteSize;

--- a/warp/db.py
+++ b/warp/db.py
@@ -13,7 +13,7 @@ DB = None
 Blobs = Table('blobs',('id','mimetype','data','etag'),primary_key='id')
 Users = Table('users',('login','password','name','account_type'))
 Groups = Table('groups',('group','login'))
-Seat = Table('seat',('id','zid','name','x','y','enabled'))
+Seat = Table('seat',('id','zid','name','x','y','enabled', 'seat_group'))
 Zone = Table('zone',('id','zone_group','name','iid'))
 ZoneAssign = Table('zone_assign',('zid','login','zone_role'))
 Book = Table('book',('id','login','sid','fromts','tots'))

--- a/warp/sql/schema.sql
+++ b/warp/sql/schema.sql
@@ -51,6 +51,7 @@ CREATE TABLE seat (
     name text NOT NULL,
     x integer NOT NULL,
     y integer NOT NULL,
+    seat_group integer,
     enabled boolean NOT NULL DEFAULT TRUE,
     FOREIGN KEY (zid) REFERENCES zone(id) ON DELETE CASCADE
     );
@@ -171,8 +172,8 @@ BEGIN
         (SELECT 1 FROM book b
          JOIN seat s on b.sid = s.id
          JOIN zone z on s.zid = z.id
-         WHERE z.zone_group =
-            (SELECT zone_group FROM zone z JOIN seat s on z.id = s.zid WHERE s.id = NEW.sid LIMIT 1)
+         WHERE COALESCE(s.seat_group, z.zone_group) =
+            (SELECT COALESCE(seat_group, zone_group) FROM zone z JOIN seat s on z.id = s.zid WHERE s.id = NEW.sid LIMIT 1)
          AND (b.sid = NEW.sid OR b.login = NEW.login)
          AND b.fromTS < NEW.toTS
          AND b.toTS > NEW.fromTS) IS NOT NULL

--- a/warp/static/i18n/de.js
+++ b/warp/static/i18n/de.js
@@ -207,6 +207,7 @@ warpGlobals.i18n.phrases = {
         "Seat name": "Sitzname",
         "X": "X",
         "Y": "Y",
+        "group": "Gruppe",
     },
     "All unsaved changes will be lost.": "Alle ungespeicherten Inforamtionen gehen verloren.",
     "More than %{smart_count} rows are selected. Report will be limited to that number of rows.":

--- a/warp/static/i18n/en.js
+++ b/warp/static/i18n/en.js
@@ -207,6 +207,7 @@ warpGlobals.i18n.phrases = {
         "Seat name": "Seat name",
         "X": "X",
         "Y": "Y",
+        "group": "Group",
     },
     "All unsaved changes will be lost.": "All unsaved changes will be lost.",
     "More than %{smart_count} rows are selected. Report will be limited to that number of rows.":

--- a/warp/static/i18n/es.js
+++ b/warp/static/i18n/es.js
@@ -205,6 +205,7 @@ warpGlobals.i18n.phrases = {
         "Seat name": "Nombre del asiento",
         "X": "X",
         "Y": "Y",
+        "group": "Grupo"
     },
     "All unsaved changes will be lost.": "Todos los cambios sin guardar se perderán.",
     "More than %{smart_count} rows are selected. Report will be limited to that number of rows.":

--- a/warp/static/i18n/fr.js
+++ b/warp/static/i18n/fr.js
@@ -205,6 +205,7 @@ warpGlobals.i18n.phrases = {
         "Seat name": "Nom du siège",
         "X": "X",
         "Y": "Y",
+        "group": "Groupe",
     },
     "All unsaved changes will be lost.": "Toutes les modifications non enregistrées seront perdues.",
     "More than %{smart_count} rows are selected. Report will be limited to that number of rows.":

--- a/warp/static/i18n/pl.js
+++ b/warp/static/i18n/pl.js
@@ -211,6 +211,7 @@ warpGlobals.i18n.phrases = {
         "Seat name": "Nazwa",
         "X": "X",
         "Y": "Y",
+        "group": "Grupa",
     },
     "All unsaved changes will be lost.": "Wszystkie niezapisane zmiany zostaną utracone.",
     "More than %{smart_count} rows are selected. Report will be limited to that number of rows.":

--- a/warp/templates/zone_modify.html
+++ b/warp/templates/zone_modify.html
@@ -45,6 +45,10 @@
             <input id="seat_y" type="number" min="0">
             <label for="seat_y" class="TR">seatEdit.Y</label>
           </div>
+          <div class="input-field">
+            <input id="seat_group" type="number" min="0">
+            <label for="seat_group" class="TR">seatEdit.group</label>
+          </div>
           <div class="input-field center-align">
             <a class="waves-effect waves-light btn TR" id="seat_delete_btn">btn.Delete</a>
           </div>

--- a/warp/xhr/zones.py
+++ b/warp/xhr/zones.py
@@ -290,10 +290,11 @@ def modify():
                         "name" : {"type" : "string"},
                         "x" : {"type" : "integer"},
                         "y" : {"type" : "integer"},
+                        "group" : {"type" : ["integer", "null"]},
                     },
                     "anyOf": [
                         {"required": ["sid"] },
-                        {"required": ["name","x","y"] },
+                        {"required": ["name","x","y","group"] },
                     ],
                 },
             },
@@ -358,7 +359,8 @@ def modify():
                     'sid': Seat.id,
                     'name': Seat.name,
                     'x': Seat.x,
-                    'y': Seat.y
+                    'y': Seat.y,
+                    'group': Seat.seat_group
                 }
 
                 dataInsert = []
@@ -399,14 +401,15 @@ def getSeats(zid):
     if not flask.g.isAdmin:
         return {"msg": "Forbidden", "code": 250 }, 403
 
-    query = Seat.select(Seat.id, Seat.name, Seat.x, Seat.y) \
+    query = Seat.select(Seat.id, Seat.name, Seat.x, Seat.y, Seat.seat_group) \
                 .where(Seat.zid == zid)
 
     res = {
         str(i['id']): {
             "name": i['name'],
             "x": i['x'],
-            "y": i['y']
+            "y": i['y'],
+            "group": i['seat_group']
             } for i in query.iterator()
     }
 


### PR DESCRIPTION
- ability to set a different group to seat in zones
- made to handle mixed zones (ie: floors with openspace, call pods and other resources than can be booked simultaneously)